### PR TITLE
changed "missing frame" message to "caching" 

### DIFF
--- a/src/duke/engine/DukeMainWindow.cpp
+++ b/src/duke/engine/DukeMainWindow.cpp
@@ -246,7 +246,7 @@ void DukeMainWindow::run() {
 					glTexParameteri(texture.target, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 					renderWithBoundTexture(m_GlyphRenderer.getGeometryRenderer().shaderPool, pSquare.get(), m_Context);
 				} else {
-					drawText(m_GlyphRenderer, m_Context.viewport, "missing frame", 100, 100, 1, 3);
+					drawText(m_GlyphRenderer, m_Context.viewport, "caching", 100, 100, 1, 3);
 				}
 			}
 			const auto& pOverlayTrack = pTrackItr->second.pOverlay;


### PR DESCRIPTION
Users tend to think that the frame is missing from the disk. I think "caching" is definitely more appropriate from a user viewpoint. It also gives a positive impression as it means the software is doing something.
