### PR TITLE
Pull request 180913

### DIFF
--- a/src/duke/benchmark/Benchmark.cpp
+++ b/src/duke/benchmark/Benchmark.cpp
@@ -128,7 +128,7 @@ void benchmark() {
 	glfwSwapInterval(0); // ensuring no vsync
 
 	SharedMesh pMesh = createSquare();
-	const ShaderDescription description = ShaderDescription::createTextureDesc(false, false, false, false, ColorSpace::Linear);
+	const ShaderDescription description = ShaderDescription::createTextureDesc(false, false, false, false, ColorSpace::Linear, ColorSpace::sRGB);
 	Program program(makeVertexShader(buildVertexShaderSource(description).c_str()), //
 			makeFragmentShader(
 					R"(

--- a/src/duke/cmdline/CmdLineParameters.cpp
+++ b/src/duke/cmdline/CmdLineParameters.cpp
@@ -112,6 +112,13 @@ void CmdLineParameters::printHelpMessage() const {
                                floating point (29.97)
                                rational number (30000/1001)
 
+      --inputspace           force the file colorspace, 
+                             [Linear, sRGB, Rec709, AlexaV3LogC, KodakLog]
+
+      --outputspace          force the display colorspace to one of 
+                             the following:
+                             [Linear, sRGB, Rec709]
+
   -f, --fullscreen           switch to fullscreen mode.
   -l, --list-formats         output supported formats and exit
   -s, --cache-size SIZE      size of the in-memory cache system in MiB,

--- a/src/duke/cmdline/CmdLineParameters.cpp
+++ b/src/duke/cmdline/CmdLineParameters.cpp
@@ -81,6 +81,16 @@ CmdLineParameters::CmdLineParameters(int argc, const char* const * argv) {
             mode = ApplicationMode::VERSION;
         else if (matches(pOption, "--list", "-l"))
             mode = ApplicationMode::LIST_SUPPORTED_FORMAT;
+        else if (matches(pOption, "", "--inputspace")) {
+			std::string colorSpaceString;
+			getArgs(argc, argv, ++i, colorSpaceString);
+			inputColorSpace = resolveFromName(colorSpaceString.c_str());
+		}
+        else if (matches(pOption, "", "--outputspace")) {
+			std::string colorSpaceString;
+			getArgs(argc, argv, ++i, colorSpaceString);
+			outputColorSpace = resolveFromName(colorSpaceString.c_str());
+		}
         else if (*pOption != '-')
             additionnalOptions.push_back(pOption);
         else

--- a/src/duke/cmdline/CmdLineParameters.hpp
+++ b/src/duke/cmdline/CmdLineParameters.hpp
@@ -5,6 +5,7 @@
 #include <stdexcept>
 
 #include <duke/time/FrameUtils.hpp>
+#include <duke/engine/ColorSpace.hpp>
 
 namespace duke {
 
@@ -29,6 +30,8 @@ struct CmdLineParameters {
 	ApplicationMode mode = ApplicationMode::DUKE;
 	FrameDuration defaultFrameRate = FrameDuration::PAL;
 	std::vector<std::string> additionnalOptions;
+	ColorSpace inputColorSpace = ColorSpace::Auto;
+	ColorSpace outputColorSpace = ColorSpace::Auto;
 
 	static unsigned getDefaultConcurrency();
 	static size_t getDefaultCacheSize();

--- a/src/duke/engine/ColorSpace.cpp
+++ b/src/duke/engine/ColorSpace.cpp
@@ -54,7 +54,17 @@ vec3 srgbtolin(vec3 sample) {
 vec3 lintosrgb(vec3 sample) {
     sample = mix((1.055*pow(sample,vec3(1/2.4)))-vec3(0.055), 12.92*sample, lessThan(sample, vec3(0.0031308)));
     return clamp(sample, vec3(0), vec3(1));
-})";
+}
+vec3 rec709tolin(vec3 sample) {
+    return mix(pow((sample+0.099)/1.099,vec3(1/0.45)), sample/4.5, lessThan(sample, vec3(0.018)));
+}
+vec3 lintorec709(vec3 sample) {
+    sample = mix((1.099*pow(sample, vec3(0.45)))-vec3(0.099), 4.5*sample, lessThan(sample, vec3(0.018)));
+    return clamp(sample, vec3(0), vec3(1));
+}
+
+)";
+
 
 const char* getToLinearFunction(const ColorSpace fromColorspace) {
     switch (fromColorspace) {
@@ -67,6 +77,8 @@ const char* getToLinearFunction(const ColorSpace fromColorspace) {
         case ColorSpace::sRGB:
         case ColorSpace::GammaCorrected:
             return "srgbtolin";
+		case ColorSpace::Rec709:
+			return "rec709tolin";
         case ColorSpace::Auto:
         default:
             throw std::runtime_error("ColorSpace must be resolved at this point");
@@ -75,16 +87,16 @@ const char* getToLinearFunction(const ColorSpace fromColorspace) {
 
 const char* getToScreenFunction(const ColorSpace fromColorspace) {
     switch (fromColorspace) {
-        case ColorSpace::AlexaLogC:
-        case ColorSpace::KodakLog:
         case ColorSpace::Linear:
             return "lintolin";
+		case ColorSpace::Rec709:
+			return "lintorec709";
         case ColorSpace::sRGB:
         case ColorSpace::GammaCorrected:
         case ColorSpace::Auto:
             return "lintosrgb"; // this is the default screen colorspace though
         default:
-            throw std::runtime_error("ColorSpace must be resolved at this point");
+            throw std::runtime_error("Screen colorspace not handled");
     }
 }
 

--- a/src/duke/engine/ColorSpace.cpp
+++ b/src/duke/engine/ColorSpace.cpp
@@ -78,10 +78,11 @@ const char* getToScreenFunction(const ColorSpace fromColorspace) {
         case ColorSpace::AlexaLogC:
         case ColorSpace::KodakLog:
         case ColorSpace::Linear:
+            return "lintolin";
         case ColorSpace::sRGB:
         case ColorSpace::GammaCorrected:
-            return "lintosrgb";
         case ColorSpace::Auto:
+            return "lintosrgb"; // this is the default screen colorspace though
         default:
             throw std::runtime_error("ColorSpace must be resolved at this point");
     }

--- a/src/duke/engine/ColorSpace.cpp
+++ b/src/duke/engine/ColorSpace.cpp
@@ -43,7 +43,7 @@ vec3 lintolin(vec3 sample) {
 	return sample;
 }
 vec3 alexatolin(vec3 sample) {
-    return mix(pow(vec3(10.0),((sample-0.385537)/0.247190)-0.052272)/5.555556 , (sample-0.092809)/5.367655, lessThan(sample, vec3(0.149658)));
+    return mix((pow(vec3(10.0),((sample-0.385537)/0.2471896))-0.052272)/5.555556 , (sample-0.092809)/5.367655, lessThan(sample, vec3(0.1496582)));
 }
 vec3 cineontolin(vec3 sample) {
 	return 1.010915615730753*(pow(vec3(10), (1023*sample-685)/300)-0.010797751623277);

--- a/src/duke/engine/ColorSpace.cpp
+++ b/src/duke/engine/ColorSpace.cpp
@@ -1,0 +1,96 @@
+#include "duke/StringUtils.hpp"
+#include "duke/engine/ColorSpace.hpp"
+
+namespace duke {
+
+ColorSpace resolveFromName(const char* pColorspace) {
+	if (pColorspace) {
+		if (streq(pColorspace, "Linear"))
+			return ColorSpace::Linear;
+		if (streq(pColorspace, "sRGB") || streq(pColorspace, "GammaCorrected"))
+			return ColorSpace::sRGB;
+		if (streq(pColorspace, "KodakLog"))
+			return ColorSpace::KodakLog;
+		if (streq(pColorspace, "Rec709"))
+			return ColorSpace::Rec709;
+		if (streq(pColorspace, "AdobeRGB"))
+			return ColorSpace::AdobeRGB;
+		if (streq(pColorspace, "AlexaV3LogC"))
+			return ColorSpace::AlexaLogC;
+	}
+	return ColorSpace::Auto;
+}
+
+ColorSpace resolveFromExtension(const char* pFileExtension) {
+	if (pFileExtension) {
+		if (streq(pFileExtension, "dpx"))
+			return ColorSpace::KodakLog;
+		if (streq(pFileExtension, "exr"))
+			return ColorSpace::Linear;
+		if (streq(pFileExtension, "jpg"))
+			return ColorSpace::sRGB;
+		if (streq(pFileExtension, "png"))
+			return ColorSpace::sRGB;
+	}
+	printf("Unable to find default ColorSpace for extension '%s' assuming sRGB\n", pFileExtension);
+	return ColorSpace::sRGB;
+}
+
+// GLSL ColorSpace conversion functions
+const char *pColorSpaceConversions =
+		R"(
+vec3 lintolin(vec3 sample) {
+	return sample;
+}
+vec3 alexatolin(vec3 sample) {
+    return mix(pow(vec3(10.0),((sample-0.385537)/0.247190)-0.052272)/5.555556 , (sample-0.092809)/5.367655, lessThan(sample, vec3(0.149658)));
+}
+vec3 cineontolin(vec3 sample) {
+	return 1.010915615730753*(pow(vec3(10), (1023*sample-685)/300)-0.010797751623277);
+}
+vec3 srgbtolin(vec3 sample) {
+    return mix(pow((sample+0.055)/1.055,vec3(2.4)), sample/12.92, lessThan(sample, vec3(0.04045)));
+}
+vec3 lintosrgb(vec3 sample) {
+    sample = mix((1.055*pow(sample,vec3(1/2.4)))-vec3(0.055), 12.92*sample, lessThan(sample, vec3(0.0031308)));
+    return clamp(sample, vec3(0), vec3(1));
+})";
+
+const char* getToLinearFunction(const ColorSpace fromColorspace) {
+    switch (fromColorspace) {
+        case ColorSpace::AlexaLogC:
+            return "alexatolin";
+        case ColorSpace::KodakLog:
+            return "cineontolin";
+        case ColorSpace::Linear:
+            return "lintolin";
+        case ColorSpace::sRGB:
+        case ColorSpace::GammaCorrected:
+            return "srgbtolin";
+        case ColorSpace::Auto:
+        default:
+            throw std::runtime_error("ColorSpace must be resolved at this point");
+    }
+}
+
+const char* getToScreenFunction(const ColorSpace fromColorspace) {
+    switch (fromColorspace) {
+        case ColorSpace::AlexaLogC:
+        case ColorSpace::KodakLog:
+        case ColorSpace::Linear:
+        case ColorSpace::sRGB:
+        case ColorSpace::GammaCorrected:
+            return "lintosrgb";
+        case ColorSpace::Auto:
+        default:
+            throw std::runtime_error("ColorSpace must be resolved at this point");
+    }
+}
+
+
+
+}//namespace duke
+
+
+
+

--- a/src/duke/engine/ColorSpace.hpp
+++ b/src/duke/engine/ColorSpace.hpp
@@ -7,4 +7,13 @@ enum class ColorSpace
 		Auto, Linear, sRGB, GammaCorrected, AdobeRGB, Rec709, KodakLog, AlexaLogC, _END
 };
 
+// Deduce a the colorspace
+ColorSpace resolveFromExtension(const char* pFileExtension);
+ColorSpace resolveFromName(const char* pColorspace);
+
+
+// GlSl functions names
+const char* getToLinearFunction(const ColorSpace fromColorspace);
+const char* getToScreenFunction(const ColorSpace fromColorspace);
+
 } /* namespace duke */

--- a/src/duke/engine/Context.hpp
+++ b/src/duke/engine/Context.hpp
@@ -33,7 +33,8 @@ struct Context {
 	glm::bvec4 channels = glm::bvec4(false);
 	float exposure = 1;
 	float gamma = 1;
-	ColorSpace colorSpace = ColorSpace::Auto;
+	ColorSpace fileColorSpace = ColorSpace::Auto;
+	ColorSpace screenColorSpace = ColorSpace::Auto;
 	// file
 	std::string filename;
 	// current drawing

--- a/src/duke/engine/rendering/ImageRenderer.cpp
+++ b/src/duke/engine/rendering/ImageRenderer.cpp
@@ -82,12 +82,16 @@ void renderWithBoundTexture(const ShaderPool &shaderPool, const Mesh *pMesh, con
 	bool redBlueSwapped = description.swapRedAndBlue;
 	if (isInternalOptimizedFormatRedBlueSwapped(description.glPackFormat))
 		redBlueSwapped = !redBlueSwapped;
+
+	const auto inputColorSpace = resolve(context.pCurrentImage->attributes, context.fileColorSpace);
+
 	const ShaderDescription shaderDesc = ShaderDescription::createTextureDesc( //
 			isGreyscale(description.glPackFormat), //
 			description.swapEndianness, //
 			redBlueSwapped, //
 			description.glPackFormat == GL_RGB10_A2UI, //
-			resolve(context.pCurrentImage->attributes, context.colorSpace));
+			inputColorSpace,
+			context.screenColorSpace);
 	const auto pProgram = shaderPool.get(shaderDesc);
 	const auto pair = getTextureDimensions(description.width, description.height, context.pCurrentImage->attributes.getOrientation());
 	pProgram->use();

--- a/src/duke/engine/rendering/ImageRenderer.cpp
+++ b/src/duke/engine/rendering/ImageRenderer.cpp
@@ -1,5 +1,4 @@
 #include "ImageRenderer.hpp"
-#include <duke/StringUtils.hpp>
 #include <duke/imageio/DukeIO.hpp>
 #include <duke/attributes/Attributes.hpp>
 #include <duke/attributes/AttributeKeys.hpp>
@@ -9,46 +8,16 @@
 #include <duke/engine/rendering/ShaderConstants.hpp>
 #include <duke/gl/Mesh.hpp>
 #include <duke/gl/Textures.hpp>
+#include <duke/engine/ColorSpace.hpp>
 
 namespace duke {
 
 namespace {
 
-ColorSpace resolveFromMetadata(const char* pColorspace) {
-	if (pColorspace) {
-		if (streq(pColorspace, "Linear"))
-			return ColorSpace::Linear;
-		if (streq(pColorspace, "sRGB") || streq(pColorspace, "GammaCorrected"))
-			return ColorSpace::sRGB;
-		if (streq(pColorspace, "KodakLog"))
-			return ColorSpace::KodakLog;
-		if (streq(pColorspace, "Rec709"))
-			return ColorSpace::Rec709;
-		if (streq(pColorspace, "AdobeRGB"))
-			return ColorSpace::AdobeRGB;
-	}
-	return ColorSpace::Auto;
-}
-
-ColorSpace resolveFromExtension(const char* pFileExtension) {
-	if (pFileExtension) {
-		if (streq(pFileExtension, "dpx"))
-			return ColorSpace::KodakLog;
-		if (streq(pFileExtension, "exr"))
-			return ColorSpace::Linear;
-		if (streq(pFileExtension, "jpg"))
-			return ColorSpace::sRGB;
-		if (streq(pFileExtension, "png"))
-			return ColorSpace::sRGB;
-	}
-	printf("Unable to find default ColorSpace for extension '%s' assuming sRGB\n", pFileExtension);
-	return ColorSpace::sRGB;
-}
-
 ColorSpace resolve(const Attributes &attributes, ColorSpace original) {
 	if (original != ColorSpace::Auto)
 		return original;
-	original = resolveFromMetadata(attributes.findString(attribute::pOiioColospaceKey));
+	original = resolveFromName(attributes.findString(attribute::pOiioColospaceKey));
 	if (original != ColorSpace::Auto)
 		return original;
 	return resolveFromExtension(attributes.findString(attribute::pDukeFileExtensionKey));

--- a/src/duke/engine/rendering/ImageRenderer.cpp
+++ b/src/duke/engine/rendering/ImageRenderer.cpp
@@ -34,6 +34,10 @@ ColorSpace resolveFromExtension(const char* pFileExtension) {
 	if (pFileExtension) {
 		if (streq(pFileExtension, "dpx"))
 			return ColorSpace::KodakLog;
+		if (streq(pFileExtension, "exr"))
+			return ColorSpace::Linear;
+		if (streq(pFileExtension, "jpg"))
+			return ColorSpace::sRGB;
 		if (streq(pFileExtension, "png"))
 			return ColorSpace::sRGB;
 	}

--- a/src/duke/engine/rendering/ShaderFactory.cpp
+++ b/src/duke/engine/rendering/ShaderFactory.cpp
@@ -14,8 +14,16 @@ extern const char *pColorSpaceConversions;
 
 namespace  {
 
-std::tuple<bool, bool, bool, bool, bool, bool, ColorSpace> asTuple(const ShaderDescription &sd) {
-	return std::make_tuple(sd.grayscale, sd.sampleTexture, sd.displayUv, sd.swapEndianness, sd.swapRedAndBlue, sd.tenBitUnpack, sd.colorspace);
+std::tuple<bool, bool, bool, bool, bool, bool, ColorSpace, ColorSpace> 
+asTuple(const ShaderDescription &sd) {
+	return std::make_tuple( sd.grayscale, 
+							sd.sampleTexture, 
+							sd.displayUv, 
+							sd.swapEndianness, 
+							sd.swapRedAndBlue, 
+							sd.tenBitUnpack, 
+							sd.fileColorspace,
+							sd.screenColorspace);
 }
 
 }  // namespace
@@ -37,14 +45,15 @@ ShaderDescription ShaderDescription::createSolidDesc() {
 	return description;
 }
 
-ShaderDescription ShaderDescription::createTextureDesc(bool grayscale, bool swapEndianness, bool swapRedAndBlue, bool tenBitUnpack, ColorSpace colorspace) {
+ShaderDescription ShaderDescription::createTextureDesc(bool grayscale, bool swapEndianness, bool swapRedAndBlue, bool tenBitUnpack, ColorSpace fileColorspace, ColorSpace screenColorspace) {
 	ShaderDescription description;
 	description.grayscale = grayscale;
 	description.sampleTexture = true;
 	description.swapEndianness = swapEndianness;
 	description.swapRedAndBlue = swapRedAndBlue;
 	description.tenBitUnpack = tenBitUnpack;
-	description.colorspace = colorspace;
+	description.fileColorspace = fileColorspace;
+	description.screenColorspace = screenColorspace;
 	return description;
 }
 
@@ -207,8 +216,8 @@ std::string buildFragmentShaderSource(const ShaderDescription &description) {
 	oss << "#version 330" << endl;
 	if (description.sampleTexture) {
 		oss << pColorSpaceConversions << endl;
-		appendToLinearFunction(oss, description.colorspace);
-		appendToScreenFunction(oss, description.colorspace);
+		appendToLinearFunction(oss, description.fileColorspace);
+		appendToScreenFunction(oss, description.screenColorspace);
 		appendSwizzle(oss, description);
 		appendSampler(oss, description);
 		oss << pTexturedMain;

--- a/src/duke/engine/rendering/ShaderFactory.cpp
+++ b/src/duke/engine/rendering/ShaderFactory.cpp
@@ -8,6 +8,10 @@ using namespace std;
 
 namespace duke {
 
+// From ColorSpace.cpp, all the conversion functions
+// in a char *
+extern const char *pColorSpaceConversions;
+
 namespace  {
 
 std::tuple<bool, bool, bool, bool, bool, bool, ColorSpace> asTuple(const ShaderDescription &sd) {
@@ -45,25 +49,6 @@ ShaderDescription ShaderDescription::createTextureDesc(bool grayscale, bool swap
 }
 
 namespace {
-
-const char pColorSpaceConversions[] =
-		R"(
-vec3 lintolin(vec3 sample) {
-	return sample;
-}
-vec3 alexatolin(vec3 sample) {
-    return mix(pow(vec3(10.0),((sample-0.385537)/0.247190)-0.052272)/5.555556 , (sample-0.092809)/5.367655, lessThan(sample, vec3(0.149658)));
-}
-vec3 cineontolin(vec3 sample) {
-	return 1.010915615730753*(pow(vec3(10), (1023*sample-685)/300)-0.010797751623277);
-}
-vec3 srgbtolin(vec3 sample) {
-    return mix(pow((sample+0.055)/1.055,vec3(2.4)), sample/12.92, lessThan(sample, vec3(0.04045)));
-}
-vec3 lintosrgb(vec3 sample) {
-    sample = mix((1.055*pow(sample,vec3(1/2.4)))-vec3(0.055), 12.92*sample, lessThan(sample, vec3(0.0031308)));
-    return clamp(sample, vec3(0), vec3(1));
-})";
 
 const char pSampleTenbitsUnpack[] =
 		R"(
@@ -192,36 +177,6 @@ void main(void)
 }
 )";
 
-const char* getToLinearFunction(const ColorSpace fromColorspace) {
-    switch (fromColorspace) {
-        case ColorSpace::AlexaLogC:
-            return "alexatolin";
-        case ColorSpace::KodakLog:
-            return "cineontolin";
-        case ColorSpace::Linear:
-            return "lintolin";
-        case ColorSpace::sRGB:
-        case ColorSpace::GammaCorrected:
-            return "srgbtolin";
-        case ColorSpace::Auto:
-        default:
-            throw std::runtime_error("ColorSpace must be resolved at this point");
-    }
-}
-
-const char* getToScreenFunction(const ColorSpace fromColorspace) {
-    switch (fromColorspace) {
-        case ColorSpace::AlexaLogC:
-        case ColorSpace::KodakLog:
-        case ColorSpace::Linear:
-        case ColorSpace::sRGB:
-        case ColorSpace::GammaCorrected:
-            return "lintosrgb";
-        case ColorSpace::Auto:
-        default:
-            throw std::runtime_error("ColorSpace must be resolved at this point");
-    }
-}
 
 void appendToLinearFunction(ostream&stream, const ColorSpace colorspace) {
 	stream << endl << "vec3 toLinear(vec3 sample){return " << getToLinearFunction(colorspace) << "(sample);}" << endl;

--- a/src/duke/engine/rendering/ShaderFactory.cpp
+++ b/src/duke/engine/rendering/ShaderFactory.cpp
@@ -95,7 +95,7 @@ smooth in vec2 vVaryingTexCoord;
 uniform sampler2DRect gTextureSampler;
 
 
-vec4 bilinear(usampler2DRect sampler, vec2 offset) {
+vec4 bilinear(sampler2DRect sampler, vec2 offset) {
     vec4 tl = swizzle(texture(sampler, offset));
     vec4 tr = swizzle(texture(sampler, offset + vec2(1, 0)));
     vec4 bl = swizzle(texture(sampler, offset + vec2(0, 1)));
@@ -106,7 +106,7 @@ vec4 bilinear(usampler2DRect sampler, vec2 offset) {
 	return mix(tA, tB, f.y);
 }
 
-vec4 nearest(usampler2DRect sampler, vec2 offset) {
+vec4 nearest(sampler2DRect sampler, vec2 offset) {
 	return swizzle(texture(sampler, offset));
 }
 
@@ -224,7 +224,7 @@ void appendToScreenFunction(ostream&stream, const ColorSpace colorspace) {
 }
 
 void appendSampler(ostream&stream, const ShaderDescription &description) {
-	const bool filtering = true; // Testing
+	const bool filtering = false; // Testing
 	const string filter(filtering ? "bilinear" : "nearest");
 	stream << (description.tenBitUnpack ? pSampleTenbitsUnpack : pSampleRegular);
 	stream << "vec4 sample(vec2 offset) {"

--- a/src/duke/engine/rendering/ShaderFactory.hpp
+++ b/src/duke/engine/rendering/ShaderFactory.hpp
@@ -15,12 +15,12 @@ struct ShaderDescription {
 	bool swapEndianness = false;
 	bool swapRedAndBlue = false;
 	bool tenBitUnpack = false;
-	ColorSpace colorspace = ColorSpace::Auto;
-
+	ColorSpace fileColorspace = ColorSpace::Auto;	// aka input colorspace
+	ColorSpace screenColorspace = ColorSpace::Auto; // aka output colorspace 
 	ShaderDescription() = default;
 	bool operator<(const ShaderDescription &other) const;
 
-	static ShaderDescription createTextureDesc(bool grayscale, bool swapEndianness, bool swapRedAndBlue, bool tenBitUnpack, ColorSpace colorspace);
+	static ShaderDescription createTextureDesc(bool grayscale, bool swapEndianness, bool swapRedAndBlue, bool tenBitUnpack, ColorSpace fileColorspace, ColorSpace screenColorspace);
 	static ShaderDescription createSolidDesc();
 	static ShaderDescription createUvDesc();
 };


### PR DESCRIPTION
Hi,
Please find with this new pull request some modifications related to colorspaces that, I hope, will help improve duke's colour management.
- The notion of a file and a display colorspace which can be different,
- 2 new colorspaces : AlexaLogC and Rec709,
- The color functions have been moved in a new ColorSpace.cpp file,
- Bilinear interpolation is available in the viewer, but not connected to any command/key.

There is also a small routine in DukeMainWindow.cpp that waits for the texture to be loaded in memory before displaying it (only when the mode is unlimitedFPS). I am not totally sure of this code, but without it we only have black images showing up. Please fill free to change/remove this part of code from the pull request.

Bests,

C
